### PR TITLE
fix: update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,10 +63,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Marco Antonio Gonzalez Junior/follow-plan-mcp.git"
+    "url": "git+https://github.com/vibeclasses/follow-plan-mcp.git"
   },
   "bugs": {
-    "url": "https://github.com/Marco Antonio Gonzalez Junior/follow-plan-mcp/issues"
+    "url": "https://github.com/vibeclasses/follow-plan-mcp/issues"
   },
-  "homepage": "https://github.com/Marco Antonio Gonzalez Junior/follow-plan-mcp#readme"
+  "homepage": "https://github.com/vibeclasses/follow-plan-mcp#readme"
 }


### PR DESCRIPTION
This pull request updates the repository metadata in the `package.json` file to reflect a change in ownership or organizational structure.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L66-R71): Updated the `repository.url`, `bugs.url`, and `homepage` fields to point to the new GitHub organization `vibeclasses` instead of `Marco Antonio Gonzalez Junior`.